### PR TITLE
build: pin aerospike setup-gpg action, setup dependabot for gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+    schedule:
+      interval: daily

--- a/.github/workflows/build-chart-jfrog.yaml
+++ b/.github/workflows/build-chart-jfrog.yaml
@@ -34,7 +34,7 @@ jobs:
 
     # You can sign helm charts but not doing this for now
     #   - name: setup GPG
-    #     uses: aerospike/shared-workflows/devops/setup-gpg@v0.1.0
+    #     uses: aerospike/shared-workflows/devops/setup-gpg@ed780e9928d56ef074532dbc6877166d5460587a # v0.1.0
     #     with:
     #       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
     #       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}

--- a/.github/workflows/build-chart-jfrog.yaml
+++ b/.github/workflows/build-chart-jfrog.yaml
@@ -34,7 +34,7 @@ jobs:
 
     # You can sign helm charts but not doing this for now
     #   - name: setup GPG
-    #     uses: aerospike/shared-workflows/devops/setup-gpg@main
+    #     uses: aerospike/shared-workflows/devops/setup-gpg@v0.1.0
     #     with:
     #       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
     #       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}


### PR DESCRIPTION
the setup-gpg action is going to move in the shared-workflows folder. 
Pinning to `main` isn't safe when that happens, so you should pin to the current semver version.

Also sets up dependabot to check and PR updates to actions weekly.