### PR TITLE
CONNECTOR-1645 - Add connector chart packaging and integration test workflows

### DIFF
--- a/.github/workflows/connector-integration-tests.yaml
+++ b/.github/workflows/connector-integration-tests.yaml
@@ -1,0 +1,280 @@
+name: Connector Integration Tests
+
+# Runs connector Helm chart integration tests on kind using the scripts under
+# ci/connectors/ and each chart's tests/integration-test/ directory.
+#
+# Triggers:
+# - workflow_call: invoked by package-connector-charts after packaging (works pre-merge)
+# - workflow_dispatch: manual run from any branch (requires workflow on default branch)
+# - pull_request: changed connector chart directories on internal PRs
+#
+# Requires repository secret FEATURES_CONF containing the Aerospike features.conf contents.
+
+on:
+  workflow_call:
+    inputs:
+      aerospike_elasticsearch_outbound:
+        type: boolean
+        required: true
+      aerospike_esp_outbound:
+        type: boolean
+        required: true
+      aerospike_jms_inbound:
+        type: boolean
+        required: true
+      aerospike_jms_outbound:
+        type: boolean
+        required: true
+      aerospike_kafka_outbound:
+        type: boolean
+        required: true
+      aerospike_pulsar_outbound:
+        type: boolean
+        required: true
+      aerospike_xdr_proxy:
+        type: boolean
+        required: true
+  workflow_dispatch:
+    inputs:
+      aerospike_elasticsearch_outbound:
+        description: aerospike-elasticsearch-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_esp_outbound:
+        description: aerospike-esp-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_jms_inbound:
+        description: aerospike-jms-inbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_jms_outbound:
+        description: aerospike-jms-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_kafka_outbound:
+        description: aerospike-kafka-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_pulsar_outbound:
+        description: aerospike-pulsar-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_xdr_proxy:
+        description: aerospike-xdr-proxy
+        type: boolean
+        required: true
+        default: true
+  pull_request:
+    paths:
+      - "aerospike-elasticsearch-outbound/**"
+      - "aerospike-esp-outbound/**"
+      - "aerospike-jms-inbound/**"
+      - "aerospike-jms-outbound/**"
+      - "aerospike-kafka-outbound/**"
+      - "aerospike-pulsar-outbound/**"
+      - "aerospike-xdr-proxy/**"
+      - "ci/connectors/**"
+      - ".github/workflows/connector-integration-tests.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: connector-integration-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      connectors_json: ${{ steps.build-matrix.outputs.connectors_json }}
+      has_connectors: ${{ steps.build-matrix.outputs.has_connectors }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Build connector test matrix
+        id: build-matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          ES: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_elasticsearch_outbound && 'true' || 'false') || github.event.inputs.aerospike_elasticsearch_outbound }}
+          ESP: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_esp_outbound && 'true' || 'false') || github.event.inputs.aerospike_esp_outbound }}
+          JMS_IN: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_jms_inbound && 'true' || 'false') || github.event.inputs.aerospike_jms_inbound }}
+          JMS_OUT: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_jms_outbound && 'true' || 'false') || github.event.inputs.aerospike_jms_outbound }}
+          KAFKA: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_kafka_outbound && 'true' || 'false') || github.event.inputs.aerospike_kafka_outbound }}
+          PULSAR: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_pulsar_outbound && 'true' || 'false') || github.event.inputs.aerospike_pulsar_outbound }}
+          XDR: ${{ github.event_name == 'workflow_call' && (inputs.aerospike_xdr_proxy && 'true' || 'false') || github.event.inputs.aerospike_xdr_proxy }}
+        run: |
+          set -euo pipefail
+
+          all_connectors=(
+            aerospike-elasticsearch-outbound
+            aerospike-esp-outbound
+            aerospike-jms-inbound
+            aerospike-jms-outbound
+            aerospike-kafka-outbound
+            aerospike-pulsar-outbound
+            aerospike-xdr-proxy
+          )
+
+          selected=()
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] || [ "${EVENT_NAME}" = "workflow_call" ]; then
+            [ "${ES}" = "true" ] && selected+=("aerospike-elasticsearch-outbound")
+            [ "${ESP}" = "true" ] && selected+=("aerospike-esp-outbound")
+            [ "${JMS_IN}" = "true" ] && selected+=("aerospike-jms-inbound")
+            [ "${JMS_OUT}" = "true" ] && selected+=("aerospike-jms-outbound")
+            [ "${KAFKA}" = "true" ] && selected+=("aerospike-kafka-outbound")
+            [ "${PULSAR}" = "true" ] && selected+=("aerospike-pulsar-outbound")
+            [ "${XDR}" = "true" ] && selected+=("aerospike-xdr-proxy")
+          else
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "Skipping fork pull request (secrets unavailable)."
+              echo 'connectors_json={"connector":[]}' >> "${GITHUB_OUTPUT}"
+              echo "has_connectors=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            changed_files="$(git diff --name-only "origin/${BASE_REF}"...HEAD)"
+            for connector in "${all_connectors[@]}"; do
+              if echo "${changed_files}" | grep -q "^${connector}/"; then
+                selected+=("${connector}")
+              fi
+            done
+          fi
+
+          if [ "${#selected[@]}" -eq 0 ]; then
+            echo "No connectors selected for testing."
+            echo 'connectors_json={"connector":[]}' >> "${GITHUB_OUTPUT}"
+            echo "has_connectors=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          connectors_json="$(printf '%s\n' "${selected[@]}" | jq -R . | jq -s -c '{connector: .}')"
+          echo "connectors_json=${connectors_json}" >> "${GITHUB_OUTPUT}"
+          echo "has_connectors=true" >> "${GITHUB_OUTPUT}"
+          echo "Selected connectors:"
+          printf '  - %s\n' "${selected[@]}"
+
+  integration-test:
+    needs: prepare
+    if: needs.prepare.outputs.has_connectors == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.connectors_json) }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.16.4
+
+      - name: Setup kind
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        with:
+          install_only: true
+          version: v0.26.0
+
+      - name: Install Aerospike features.conf
+        env:
+          FEATURES_CONF: ${{ secrets.FEATURES_CONF }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${FEATURES_CONF}" ]; then
+            echo "::error::Missing repository secret FEATURES_CONF"
+            exit 1
+          fi
+
+          mkdir -p "${{ matrix.connector }}/kind/config"
+          printf '%s\n' "${FEATURES_CONF}" > "${{ matrix.connector }}/kind/config/features.conf"
+          chmod 600 "${{ matrix.connector }}/kind/config/features.conf"
+
+      - name: Install Kind cluster
+        run: |
+          set -o pipefail
+          bash "${{ matrix.connector }}/kind/install-kind.sh" 2>&1 | tee "/tmp/${{ matrix.connector }}-install.log"
+
+      - name: Run integration test
+        id: integration-test
+        run: |
+          set -o pipefail
+          test_output="/tmp/${{ matrix.connector }}-test.log"
+          set +e
+          bash "${{ matrix.connector }}/tests/integration-test/run-integration-test.sh" 2>&1 | tee "${test_output}"
+          test_exit_code=${PIPESTATUS[0]}
+          set -e
+
+          if grep -q "^INTEGRATION_TEST_FAILED$" "${test_output}"; then
+            echo "result=failed" >> "${GITHUB_OUTPUT}"
+            exit 1
+          fi
+
+          if [ "${test_exit_code}" -eq 0 ] || grep -q "^INTEGRATION_TEST_PASSED$" "${test_output}"; then
+            echo "result=passed" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "result=failed" >> "${GITHUB_OUTPUT}"
+          exit 1
+
+      - name: Uninstall Kind cluster
+        if: always()
+        run: |
+          set -o pipefail
+          bash "${{ matrix.connector }}/kind/uninstall-kind.sh" 2>&1 | tee "/tmp/${{ matrix.connector }}-uninstall.log" || true
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: integration-test-logs-${{ matrix.connector }}-${{ github.run_id }}
+          path: /tmp/${{ matrix.connector }}-*.log
+          if-no-files-found: warn
+          retention-days: 14
+
+  summary:
+    needs: [prepare, integration-test]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report no scheduled tests
+        if: needs.prepare.outputs.has_connectors != 'true'
+        run: echo "No connector integration tests were scheduled for this event."
+
+      - name: Report success
+        if: needs.prepare.outputs.has_connectors == 'true' && needs.integration-test.result == 'success'
+        run: echo "All selected connector integration tests passed."
+
+      - name: Report failure
+        if: needs.prepare.outputs.has_connectors == 'true' && needs.integration-test.result == 'failure'
+        run: |
+          echo "::error::One or more connector integration tests failed."
+          exit 1

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -1,0 +1,427 @@
+name: Package Connector Helm Charts
+
+# Packages selected connector Helm charts into docs/, refreshes docs/index.yaml,
+# and opens a pull request to main.
+#
+# Intended release flow:
+#   1. Create a feature branch with chart updates from the connector release project
+#   2. Run integration tests from that branch
+#   3. Run this workflow from the same branch to package charts and open/update the PR
+#   4. Integration tests run automatically after packaging succeeds
+#   5. Review and merge to main only after tests and packaging look correct
+#
+# Optional: configure the "connector-helm-release" environment with required reviewers
+# for an additional approval gate before packaging commits are pushed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      aerospike_elasticsearch_outbound:
+        description: aerospike-elasticsearch-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_esp_outbound:
+        description: aerospike-esp-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_jms_inbound:
+        description: aerospike-jms-inbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_jms_outbound:
+        description: aerospike-jms-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_kafka_outbound:
+        description: aerospike-kafka-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_pulsar_outbound:
+        description: aerospike-pulsar-outbound
+        type: boolean
+        required: true
+        default: true
+      aerospike_xdr_proxy:
+        description: aerospike-xdr-proxy
+        type: boolean
+        required: true
+        default: true
+      version_bump:
+        description: Default version bump (patch, minor, major, none) or explicit semver for all selected charts
+        type: string
+        required: false
+        default: patch
+      chart_version_overrides:
+        description: Optional JSON map of chart directory to bump mode or semver (overrides version_bump per chart)
+        type: string
+        required: false
+        default: ""
+      branch_mode:
+        description: Branch handling mode for the release PR branch
+        type: choice
+        required: true
+        default: update_existing
+        options:
+          - create_new
+          - update_existing
+      branch_name:
+        description: Release PR branch (leave empty to use the branch this workflow runs from)
+        required: false
+        default: ""
+      jira_ticket:
+        description: JIRA ticket for the PR title (e.g. CONNECTOR-1558)
+        required: false
+        default: ""
+      pr_title:
+        description: Optional custom PR title (overrides default when set)
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: package-connector-charts-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package-connector-charts:
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.selected-charts.outputs.charts }}
+      release_branch: ${{ steps.release-branch.outputs.name }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout triggering branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release branch
+        id: release-branch
+        env:
+          INPUT_BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+          BRANCH_MODE: ${{ github.event.inputs.branch_mode }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${INPUT_BRANCH_NAME}" ]; then
+            target_branch="${INPUT_BRANCH_NAME}"
+          else
+            target_branch="${GITHUB_REF_NAME}"
+          fi
+
+          echo "Triggering branch: ${GITHUB_REF_NAME}"
+          echo "Release PR branch: ${target_branch}"
+
+          if git ls-remote --heads origin "${target_branch}" | grep -q .; then
+            if [ "${BRANCH_MODE}" = "create_new" ] && [ "${target_branch}" != "${GITHUB_REF_NAME}" ]; then
+              echo "::error::Branch '${target_branch}' already exists. Choose a different branch name or use update_existing mode."
+              exit 1
+            fi
+            echo "Release branch exists and will be updated."
+          elif [ "${BRANCH_MODE}" = "create_new" ]; then
+            echo "Release branch will be created."
+          else
+            echo "Release branch does not exist yet; it will be created on first push."
+          fi
+
+          echo "name=${target_branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve selected charts
+        id: selected-charts
+        env:
+          AEROSPIKE_ELASTICSEARCH_OUTBOUND: ${{ github.event.inputs.aerospike_elasticsearch_outbound }}
+          AEROSPIKE_ESP_OUTBOUND: ${{ github.event.inputs.aerospike_esp_outbound }}
+          AEROSPIKE_JMS_INBOUND: ${{ github.event.inputs.aerospike_jms_inbound }}
+          AEROSPIKE_JMS_OUTBOUND: ${{ github.event.inputs.aerospike_jms_outbound }}
+          AEROSPIKE_KAFKA_OUTBOUND: ${{ github.event.inputs.aerospike_kafka_outbound }}
+          AEROSPIKE_PULSAR_OUTBOUND: ${{ github.event.inputs.aerospike_pulsar_outbound }}
+          AEROSPIKE_XDR_PROXY: ${{ github.event.inputs.aerospike_xdr_proxy }}
+        run: |
+          set -euo pipefail
+
+          charts=()
+          if [ "${AEROSPIKE_ELASTICSEARCH_OUTBOUND}" = "true" ]; then charts+=("aerospike-elasticsearch-outbound"); fi
+          if [ "${AEROSPIKE_ESP_OUTBOUND}" = "true" ]; then charts+=("aerospike-esp-outbound"); fi
+          if [ "${AEROSPIKE_JMS_INBOUND}" = "true" ]; then charts+=("aerospike-jms-inbound"); fi
+          if [ "${AEROSPIKE_JMS_OUTBOUND}" = "true" ]; then charts+=("aerospike-jms-outbound"); fi
+          if [ "${AEROSPIKE_KAFKA_OUTBOUND}" = "true" ]; then charts+=("aerospike-kafka-outbound"); fi
+          if [ "${AEROSPIKE_PULSAR_OUTBOUND}" = "true" ]; then charts+=("aerospike-pulsar-outbound"); fi
+          if [ "${AEROSPIKE_XDR_PROXY}" = "true" ]; then charts+=("aerospike-xdr-proxy"); fi
+
+          if [ "${#charts[@]}" -eq 0 ]; then
+            echo "::error::Select at least one connector chart to package."
+            exit 1
+          fi
+
+          {
+            echo "charts<<EOF"
+            printf '%s\n' "${charts[@]}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Selected charts:"
+          printf '  - %s\n' "${charts[@]}"
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.16.4
+
+      - name: Bump chart versions and update README tags
+        if: >-
+          ${{
+            (github.event.inputs.version_bump != 'none' && github.event.inputs.version_bump != 'skip' && github.event.inputs.version_bump != '')
+            || (github.event.inputs.chart_version_overrides != '')
+          }}
+        env:
+          CHARTS: ${{ steps.selected-charts.outputs.charts }}
+          VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
+          CHART_VERSION_OVERRIDES: ${{ github.event.inputs.chart_version_overrides }}
+        run: |
+          set -euo pipefail
+
+          bump_version() {
+            local version="${1//\"/}"
+            local bump_type="${2,,}"
+
+            if [[ "${bump_type}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "${bump_type}"
+              return
+            fi
+
+            local major minor patch
+            IFS='.' read -r major minor patch <<< "${version}"
+
+            case "${bump_type}" in
+              patch)
+                echo "${major}.${minor}.$((patch + 1))"
+                ;;
+              minor)
+                echo "${major}.$((minor + 1)).0"
+                ;;
+              major)
+                echo "$((major + 1)).0.0"
+                ;;
+              *)
+                echo "::error::Unknown bump type '${2}'. Use patch, minor, major, none, skip, or an explicit version (e.g. 4.0.0)." >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          should_skip_bump() {
+            local bump_type="${1,,}"
+            [ -z "${bump_type}" ] || [ "${bump_type}" = "none" ] || [ "${bump_type}" = "skip" ]
+          }
+
+          resolve_bump_type() {
+            local chart="$1"
+            local override=""
+
+            if [ -n "${CHART_VERSION_OVERRIDES}" ]; then
+              override="$(echo "${CHART_VERSION_OVERRIDES}" | jq -r --arg chart "${chart}" '.[$chart] // empty')"
+            fi
+
+            if [ -n "${override}" ] && [ "${override}" != "null" ]; then
+              echo "${override}"
+            else
+              echo "${VERSION_BUMP}"
+            fi
+          }
+
+          if [ -n "${CHART_VERSION_OVERRIDES}" ]; then
+            if ! echo "${CHART_VERSION_OVERRIDES}" | jq -e 'type == "object"' >/dev/null; then
+              echo "::error::chart_version_overrides must be a JSON object, e.g. {\"aerospike-kafka-outbound\":\"6.0.3\"}"
+              exit 1
+            fi
+
+            while IFS= read -r chart_key; do
+              [ -n "${chart_key}" ] || continue
+              if ! grep -qx "${chart_key}" <<< "${CHARTS}"; then
+                echo "::error::chart_version_overrides contains unselected or unknown chart '${chart_key}'"
+                exit 1
+              fi
+            done <<< "$(echo "${CHART_VERSION_OVERRIDES}" | jq -r 'keys[]')"
+          fi
+
+          version_changes=()
+
+          while IFS= read -r chart; do
+            [ -n "${chart}" ] || continue
+
+            chart_yaml="${chart}/Chart.yaml"
+            if [ ! -f "${chart_yaml}" ]; then
+              echo "::error::Missing ${chart_yaml}"
+              exit 1
+            fi
+
+            old_version="$(grep '^version:' "${chart_yaml}" | head -n1 | awk '{print $2}' | tr -d '"')"
+            chart_bump="$(resolve_bump_type "${chart}")"
+
+            if should_skip_bump "${chart_bump}"; then
+              echo "${chart}: keeping ${old_version}"
+              continue
+            fi
+
+            new_version="$(bump_version "${old_version}" "${chart_bump}")"
+
+            sed -i "s/^version: .*/version: \"${new_version}\"/" "${chart_yaml}"
+            sed -i "s/^appVersion: .*/appVersion: \"${new_version}\"/" "${chart_yaml}"
+
+            readme="${chart}/README.md"
+            if [ -f "${readme}" ]; then
+              sed -i "s/tag: \"${old_version}\"/tag: \"${new_version}\"/" "${readme}"
+            fi
+
+            version_changes+=("| ${chart} | ${old_version} → ${new_version} (${chart_bump}) |")
+            echo "${chart}: ${old_version} -> ${new_version} (${chart_bump})"
+          done <<< "${CHARTS}"
+
+          {
+            echo "summary<<EOF"
+            printf '%s\n' "${version_changes[@]}"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Package selected connector charts
+        env:
+          CHARTS: ${{ steps.selected-charts.outputs.charts }}
+        run: |
+          set -euo pipefail
+
+          chart_args=()
+          while IFS= read -r chart; do
+            [ -n "${chart}" ] || continue
+            chart_args+=("${chart}")
+          done <<< "${CHARTS}"
+
+          helm package "${chart_args[@]}" --destination docs/
+
+      - name: Regenerate Helm repository index
+        env:
+          CHARTS: ${{ steps.selected-charts.outputs.charts }}
+        run: |
+          set -euo pipefail
+
+          # Index only newly packaged charts so historical `created` timestamps
+          # in docs/index.yaml are preserved (helm repo index on docs/ re-reads
+          # every .tgz and resets created from file mtimes).
+          staging="$(mktemp -d)"
+          trap 'rm -rf "${staging}"' EXIT
+
+          while IFS= read -r chart; do
+            [ -n "${chart}" ] || continue
+            version="$(grep '^version:' "${chart}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+            tgz="docs/${chart}-${version}.tgz"
+            if [ ! -f "${tgz}" ]; then
+              echo "::error::Missing packaged chart ${tgz}"
+              exit 1
+            fi
+            cp "${tgz}" "${staging}/"
+          done <<< "${CHARTS}"
+
+          helm repo index "${staging}" --merge docs/index.yaml --url https://aerospike.github.io/helm-charts
+          mv "${staging}/index.yaml" docs/index.yaml
+
+      - name: Build pull request metadata
+        id: pr-metadata
+        env:
+          VERSION_BUMP: ${{ github.event.inputs.version_bump || 'patch' }}
+          CHART_VERSION_OVERRIDES: ${{ github.event.inputs.chart_version_overrides }}
+          JIRA_TICKET: ${{ github.event.inputs.jira_ticket }}
+          PR_TITLE_INPUT: ${{ github.event.inputs.pr_title }}
+          VERSION_SUMMARY: ${{ env.summary }}
+          RELEASE_BRANCH: ${{ steps.release-branch.outputs.name }}
+        run: |
+          set -euo pipefail
+
+          should_bump=false
+          if [ -n "${CHART_VERSION_OVERRIDES}" ]; then
+            should_bump=true
+          elif [ -n "${VERSION_BUMP}" ] && [ "${VERSION_BUMP}" != "none" ] && [ "${VERSION_BUMP}" != "skip" ]; then
+            should_bump=true
+          fi
+
+          if [ -n "${PR_TITLE_INPUT}" ]; then
+            title="${PR_TITLE_INPUT}"
+          elif [ -n "${JIRA_TICKET}" ]; then
+            title="[${JIRA_TICKET}] - Bump connector Helm chart versions"
+          else
+            title="Bump connector Helm chart versions"
+          fi
+
+          {
+            echo "title<<EOF"
+            echo "${title}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "body<<EOF"
+            echo "## Summary"
+            echo "- Package selected connector Helm charts into \`docs/\`"
+            if [ "${should_bump}" = "true" ]; then
+              if [ -n "${CHART_VERSION_OVERRIDES}" ]; then
+                echo "- Update chart versions using per-chart overrides and default \`${VERSION_BUMP}\`"
+              else
+                echo "- Update chart versions in \`Chart.yaml\`, \`appVersion\`, and README image tags (\`${VERSION_BUMP}\`)"
+              fi
+            fi
+            echo "- Regenerate \`docs/index.yaml\` with digests for the newly packaged charts"
+            echo ""
+            echo "**Source branch:** \`${GITHUB_REF_NAME}\`"
+            echo "**Release PR branch:** \`${RELEASE_BRANCH}\`"
+            echo ""
+            if [ "${should_bump}" = "true" ] && [ -n "${VERSION_SUMMARY:-}" ]; then
+              echo "## Version updates"
+              echo "| Chart | Version |"
+              echo "|---|---|"
+              echo "${VERSION_SUMMARY}"
+              echo ""
+            fi
+            echo "## Test plan"
+            echo "- [ ] Verify \`helm repo index\` entries match packaged chart versions"
+            echo "- [ ] Confirm chart versions in Chart.yaml match appVersion for selected connectors"
+            echo "- [ ] Integration tests passed on the source branch before merge"
+            echo ""
+            echo "Triggered by @${{ github.actor }} from workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: ${{ steps.release-branch.outputs.name }}
+          delete-branch: false
+          commit-message: ${{ steps.pr-metadata.outputs.title }}
+          title: ${{ steps.pr-metadata.outputs.title }}
+          body: ${{ steps.pr-metadata.outputs.body }}
+
+  integration-tests:
+    needs: package-connector-charts
+    if: success()
+    uses: ./.github/workflows/connector-integration-tests.yaml
+    secrets: inherit
+    with:
+      aerospike_elasticsearch_outbound: ${{ github.event.inputs.aerospike_elasticsearch_outbound == 'true' }}
+      aerospike_esp_outbound: ${{ github.event.inputs.aerospike_esp_outbound == 'true' }}
+      aerospike_jms_inbound: ${{ github.event.inputs.aerospike_jms_inbound == 'true' }}
+      aerospike_jms_outbound: ${{ github.event.inputs.aerospike_jms_outbound == 'true' }}
+      aerospike_kafka_outbound: ${{ github.event.inputs.aerospike_kafka_outbound == 'true' }}
+      aerospike_pulsar_outbound: ${{ github.event.inputs.aerospike_pulsar_outbound == 'true' }}
+      aerospike_xdr_proxy: ${{ github.event.inputs.aerospike_xdr_proxy == 'true' }}

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -27,6 +27,63 @@ cd /path/to/helm-charts
 ./ci/connectors/run-all-connector-tests.sh
 ```
 
+
+### Running in GitHub Actions
+
+Workflow: **Connector Integration Tests** (`.github/workflows/connector-integration-tests.yaml`)
+
+Uses the existing repository secret `FEATURES_CONF` containing the Aerospike `features.conf` contents.
+
+**Automatic run after packaging**
+
+When **Package Connector Helm Charts** completes successfully, it calls **Connector Integration Tests** as a reusable workflow for the packaged connectors (same commit/ref as the packaging run).
+
+**Manual run**
+
+1. Open **Actions → Connector Integration Tests → Run workflow**
+2. Select the branch to test (e.g. your PR branch)
+3. Select connectors using the checkboxes (all selected by default)
+
+Manual runs require permission to trigger workflows on this repository (configure under **Settings → Actions → General**).
+
+**Pull request runs**
+
+When a pull request changes connector chart files, the workflow runs integration tests only for the affected connector chart directories. Workflow or CI documentation-only changes do not schedule integration tests on the pull request.
+
+Fork pull requests are skipped automatically because repository secrets are unavailable.
+
+Test logs are uploaded as workflow artifacts for 14 days.
+
+### Packaging connector charts
+
+Workflow: **Package Connector Helm Charts** (`.github/workflows/package-connector-charts.yaml`)
+
+**Version inputs**
+
+| Input | Purpose |
+|---|---|
+| `version_bump` | Default for all selected charts: `patch`, `minor`, `major`, `none`, or explicit `X.Y.Z` |
+| `chart_version_overrides` | Optional JSON map overriding `version_bump` per chart directory |
+
+Example overrides (each value can be a bump mode or explicit semver):
+
+```json
+{
+  "aerospike-kafka-outbound": "6.1.0",
+  "aerospike-jms-outbound": "minor",
+  "aerospike-esp-outbound": "none"
+}
+```
+
+Charts not listed in overrides use `version_bump`. With `version_bump=none`, only charts listed in overrides are updated.
+
+```bash
+gh workflow run package-connector-charts.yaml \
+  --ref <branch> \
+  -f version_bump=patch \
+  -f 'chart_version_overrides={"aerospike-kafka-outbound":"6.1.0","aerospike-jms-outbound":"4.3.0"}'
+```
+
 ### Running in Jenkins
 
 1. Create a Pipeline job in Jenkins

--- a/ci/connectors/build_scripts/build_connector_helm_indexing.sh
+++ b/ci/connectors/build_scripts/build_connector_helm_indexing.sh
@@ -1,1 +1,26 @@
-helm repo index docs --merge docs/index.yaml --url https://aerospike.github.io/helm-charts
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Merge index entries for packaged charts without resetting `created` on prior releases.
+# Pass chart directory names (same as helm package args); omit args for legacy full re-index.
+#
+# See https://github.com/helm/helm/issues/7363
+
+REPO_URL="https://aerospike.github.io/helm-charts"
+INDEX_FILE="docs/index.yaml"
+
+if [ "$#" -eq 0 ]; then
+  helm repo index docs --merge "${INDEX_FILE}" --url "${REPO_URL}"
+  exit 0
+fi
+
+staging="$(mktemp -d)"
+trap 'rm -rf "${staging}"' EXIT
+
+for chart in "$@"; do
+  version="$(grep '^version:' "${chart}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+  cp "docs/${chart}-${version}.tgz" "${staging}/"
+done
+
+helm repo index "${staging}" --merge "${INDEX_FILE}" --url "${REPO_URL}"
+mv "${staging}/index.yaml" "${INDEX_FILE}"


### PR DESCRIPTION
## Summary

Adds GitHub Actions automation for connector Helm chart releases and integration testing (replaces/supplements the Jenkins flow).

**New workflows**
- **Package Connector Helm Charts** — packages selected charts into `docs/`, updates `docs/index.yaml`, opens a release PR, and triggers integration tests via `workflow_call`
- **Connector Integration Tests** — runs kind-based integration tests in parallel for selected connectors

**Supporting changes**
- `ci/connectors/README.md` — usage docs for GHA packaging and integration tests
- `ci/connectors/build_scripts/build_connector_helm_indexing.sh` — indexes only newly packaged charts so historical `created` timestamps in `docs/index.yaml` are preserved

**Version controls** (packaging workflow inputs)
- `version_bump` — default bump mode for all selected charts: `patch`, `minor`, `major`, `none`, or explicit `X.Y.Z`
- `chart_version_overrides` — optional JSON map for per-connector bump mode or semver

**Notes**
- Integration tests run automatically after packaging via reusable workflow (works before merge to `main`)
- Requires repository secret `FEATURES_CONF`
- This PR contains **CI/workflow changes only** — no chart version or `docs/` packaging updates

## Test plan

- [x] End-to-end packaging + integration test run validated on feature branch
- [ ] Review workflow permissions and StepSecurity harden-runner settings
- [ ] Confirm `FEATURES_CONF` secret is configured on the repo
- [ ] After merge: run **Package Connector Helm Charts** from a release branch to produce chart/docs changes in a separate PR