### PR TITLE
[CONNECTOR-1645] [Streaming][All] Add connector chart packaging and integration test workflows

### DIFF
--- a/.github/workflows/connector-integration-tests.yaml
+++ b/.github/workflows/connector-integration-tests.yaml
@@ -6,13 +6,9 @@ name: Connector Integration Tests
 # Triggers:
 # - workflow_call: invoked by package-connector-charts after packaging (primary release path)
 # - workflow_dispatch: manual run from any branch
-# - pull_request: only when connector-integration-tests.yaml itself changes (human CI PRs)
+# - pull_request: CI or connector test changes (not chart packaging paths under Chart.yaml/docs/)
 #
-# Chart release PRs do not use pull_request; they run tests via workflow_call from
-# Package Connector Helm Charts to avoid duplicate runs and GitHub's approval gate
-# for pull_request workflows that use secrets on GITHUB_TOKEN-created commits.
-#
-# Requires repository secret FEATURES_CONF containing the Aerospike features.conf contents.
+# Chart release PRs run tests via workflow_call from Package Connector Helm Charts instead.
 
 on:
   workflow_call:
@@ -82,7 +78,17 @@ on:
         default: true
   pull_request:
     paths:
+      - "ci/connectors/**"
+      - "aerospike-elasticsearch-outbound/tests/**"
+      - "aerospike-esp-outbound/tests/**"
+      - "aerospike-jms-inbound/tests/**"
+      - "aerospike-jms-outbound/tests/**"
+      - "aerospike-kafka-outbound/tests/**"
+      - "aerospike-pulsar-outbound/tests/**"
+      - "aerospike-xdr-proxy/tests/**"
       - ".github/workflows/connector-integration-tests.yaml"
+
+# Requires repository secret FEATURES_CONF containing the Aerospike features.conf contents.
 
 permissions:
   contents: read
@@ -153,11 +159,20 @@ jobs:
             fi
 
             changed_files="$(git diff --name-only "origin/${BASE_REF}"...HEAD)"
-            for connector in "${all_connectors[@]}"; do
-              if echo "${changed_files}" | grep -q "^${connector}/"; then
-                selected+=("${connector}")
-              fi
-            done
+
+            if echo "${changed_files}" | grep -q '^ci/connectors/'; then
+              selected=("${all_connectors[@]}")
+            else
+              for connector in "${all_connectors[@]}"; do
+                if echo "${changed_files}" | grep -q "^${connector}/tests/"; then
+                  selected+=("${connector}")
+                fi
+              done
+            fi
+
+            if [ "${#selected[@]}" -eq 0 ] && echo "${changed_files}" | grep -q '^\.github/workflows/connector-integration-tests\.yaml$'; then
+              selected=("${all_connectors[@]}")
+            fi
           fi
 
           if [ "${#selected[@]}" -eq 0 ]; then

--- a/.github/workflows/connector-integration-tests.yaml
+++ b/.github/workflows/connector-integration-tests.yaml
@@ -4,9 +4,13 @@ name: Connector Integration Tests
 # ci/connectors/ and each chart's tests/integration-test/ directory.
 #
 # Triggers:
-# - workflow_call: invoked by package-connector-charts after packaging (works pre-merge)
-# - workflow_dispatch: manual run from any branch (requires workflow on default branch)
-# - pull_request: changed connector chart directories on internal PRs
+# - workflow_call: invoked by package-connector-charts after packaging (primary release path)
+# - workflow_dispatch: manual run from any branch
+# - pull_request: only when connector-integration-tests.yaml itself changes (human CI PRs)
+#
+# Chart release PRs do not use pull_request; they run tests via workflow_call from
+# Package Connector Helm Charts to avoid duplicate runs and GitHub's approval gate
+# for pull_request workflows that use secrets on GITHUB_TOKEN-created commits.
 #
 # Requires repository secret FEATURES_CONF containing the Aerospike features.conf contents.
 
@@ -78,14 +82,6 @@ on:
         default: true
   pull_request:
     paths:
-      - "aerospike-elasticsearch-outbound/**"
-      - "aerospike-esp-outbound/**"
-      - "aerospike-jms-inbound/**"
-      - "aerospike-jms-outbound/**"
-      - "aerospike-kafka-outbound/**"
-      - "aerospike-pulsar-outbound/**"
-      - "aerospike-xdr-proxy/**"
-      - "ci/connectors/**"
       - ".github/workflows/connector-integration-tests.yaml"
 
 permissions:

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -398,7 +398,7 @@ jobs:
           commit-message: ${{ steps.pr-metadata.outputs.title }}
           title: ${{ steps.pr-metadata.outputs.title }}
           body: ${{ steps.pr-metadata.outputs.body }}
-          reviewers: mphanias,abhilashmandaliya,vivekashub
+          reviewers: mphanias,abhilashmandaliya,VivekASHub
 
   integration-tests:
     needs: package-connector-charts

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -324,6 +324,70 @@ jobs:
           helm repo index "${staging}" --merge docs/index.yaml --url https://aerospike.github.io/helm-charts
           mv "${staging}/index.yaml" docs/index.yaml
 
+      - name: Verify packaged chart artifacts
+        env:
+          CHARTS: ${{ steps.selected-charts.outputs.charts }}
+        run: |
+          set -euo pipefail
+
+          verification_lines=()
+
+          while IFS= read -r chart; do
+            [ -n "${chart}" ] || continue
+
+            version="$(grep '^version:' "${chart}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+            app_version="$(grep '^appVersion:' "${chart}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+            tgz="docs/${chart}-${version}.tgz"
+
+            if [ ! -f "${tgz}" ]; then
+              echo "::error::Missing packaged chart ${tgz}"
+              exit 1
+            fi
+
+            echo "::group::${chart} ${version}"
+            echo "Chart.yaml: version=${version} appVersion=${app_version}"
+            echo "Artifact: ${tgz}"
+
+            file_digest="$(sha256sum "${tgz}" | awk '{print $1}')"
+            echo "sha256: ${file_digest}"
+
+            index_digest="$(ruby -ryaml -e "
+              index = YAML.load_file('docs/index.yaml')
+              entry = index.dig('entries', '${chart}')&.find { |e| e['version'].to_s == '${version}' }
+              abort('missing index entry') unless entry
+              puts entry['digest']
+            ")"
+
+            if [ "${file_digest}" != "${index_digest}" ]; then
+              echo "::error::Digest mismatch for ${tgz}: file=${file_digest} index=${index_digest}"
+              exit 1
+            fi
+
+            echo "index digest: ${index_digest} (matches)"
+
+            packaged_version="$(helm show chart "${tgz}" | awk '/^version:/ {print $2}' | tr -d '"')"
+            packaged_app_version="$(helm show chart "${tgz}" | awk '/^appVersion:/ {print $2}' | tr -d '"')"
+
+            if [ "${packaged_version}" != "${version}" ] || [ "${packaged_app_version}" != "${app_version}" ]; then
+              echo "::error::Packaged chart metadata mismatch for ${tgz}"
+              echo "expected version=${version} appVersion=${app_version}"
+              echo "got version=${packaged_version} appVersion=${packaged_app_version}"
+              exit 1
+            fi
+
+            echo "--- helm show chart ---"
+            helm show chart "${tgz}"
+            echo "::endgroup::"
+
+            verification_lines+=("| ${chart} | ${version} | \`${file_digest}\` | verified |")
+          done <<< "${CHARTS}"
+
+          {
+            echo "package_verification<<EOF"
+            printf '%s\n' "${verification_lines[@]}"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
+
       - name: Build pull request metadata
         id: pr-metadata
         env:
@@ -331,6 +395,7 @@ jobs:
           CHART_VERSION_OVERRIDES: ${{ github.event.inputs.chart_version_overrides }}
           PR_TITLE_INPUT: ${{ github.event.inputs.pr_title }}
           VERSION_SUMMARY: ${{ env.summary }}
+          PACKAGE_VERIFICATION: ${{ env.package_verification }}
           FEATURE_BRANCH: ${{ steps.feature-branch.outputs.name }}
           CHECKOUT_REF: ${{ steps.feature-branch.outputs.checkout_ref }}
         run: |
@@ -377,6 +442,13 @@ jobs:
               echo "| Chart | Version |"
               echo "|---|---|"
               echo "${VERSION_SUMMARY}"
+              echo ""
+            fi
+            if [ -n "${PACKAGE_VERIFICATION:-}" ]; then
+              echo "## Packaged artifacts"
+              echo "| Chart | Version | SHA256 | Status |"
+              echo "|---|---|---|---|"
+              echo "${PACKAGE_VERIFICATION}"
               echo ""
             fi
             echo "## Test plan"

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -62,7 +62,7 @@ on:
         description: JIRA feature branch and PR head (e.g. CONNECTOR-1645)
         required: true
       pr_title:
-        description: PR title after the JIRA prefix (default - Bump connector Helm chart versions)
+        description: PR title suffix after the JIRA prefix (default - [Streaming] release title with current Mon'YY in IST)
         required: false
         default: ""
 
@@ -285,6 +285,7 @@ jobs:
       - name: Package selected connector charts
         env:
           CHARTS: ${{ steps.selected-charts.outputs.charts }}
+          TZ: Asia/Kolkata
         run: |
           set -euo pipefail
 
@@ -299,12 +300,13 @@ jobs:
       - name: Regenerate Helm repository index
         env:
           CHARTS: ${{ steps.selected-charts.outputs.charts }}
+          TZ: Asia/Kolkata
         run: |
           set -euo pipefail
 
           # Index only newly packaged charts so historical `created` timestamps
-          # in docs/index.yaml are preserved (helm repo index on docs/ re-reads
-          # every .tgz and resets created from file mtimes).
+          # in docs/index.yaml are preserved. TZ=Asia/Kolkata keeps new entries
+          # in +05:30 like prior releases (GHA default UTC otherwise).
           staging="$(mktemp -d)"
           trap 'rm -rf "${staging}"' EXIT
 
@@ -344,7 +346,8 @@ jobs:
           if [ -n "${PR_TITLE_INPUT}" ]; then
             title="[${FEATURE_BRANCH}] ${PR_TITLE_INPUT}"
           else
-            title="[${FEATURE_BRANCH}] Bump connector Helm chart versions"
+            release_month_year="$(TZ=Asia/Kolkata date +"%b'%y")"
+            title="[${FEATURE_BRANCH}] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - ${release_month_year}"
           fi
 
           {
@@ -395,6 +398,7 @@ jobs:
           commit-message: ${{ steps.pr-metadata.outputs.title }}
           title: ${{ steps.pr-metadata.outputs.title }}
           body: ${{ steps.pr-metadata.outputs.body }}
+          reviewers: mphanias,abhilashmandaliya,vivekashub
 
   integration-tests:
     needs: package-connector-charts

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -13,6 +13,23 @@ name: Package Connector Helm Charts
 on:
   workflow_dispatch:
     inputs:
+      branch_name:
+        description: JIRA feature branch and PR head (e.g. CONNECTOR-1645)
+        required: true
+      pr_title:
+        description: PR title suffix after the JIRA prefix (default - [Streaming] release title with current Mon'YY in IST)
+        required: false
+        default: ""
+      version_bump:
+        description: Default version bump (patch, minor, major, none) or explicit semver for all selected charts
+        type: string
+        required: false
+        default: patch
+      chart_version_overrides:
+        description: Optional JSON map of chart directory to bump mode or semver (overrides version_bump per chart)
+        type: string
+        required: false
+        default: ""
       aerospike_elasticsearch_outbound:
         description: aerospike-elasticsearch-outbound
         type: boolean
@@ -48,23 +65,6 @@ on:
         type: boolean
         required: true
         default: true
-      version_bump:
-        description: Default version bump (patch, minor, major, none) or explicit semver for all selected charts
-        type: string
-        required: false
-        default: patch
-      chart_version_overrides:
-        description: Optional JSON map of chart directory to bump mode or semver (overrides version_bump per chart)
-        type: string
-        required: false
-        default: ""
-      branch_name:
-        description: JIRA feature branch and PR head (e.g. CONNECTOR-1645)
-        required: true
-      pr_title:
-        description: PR title suffix after the JIRA prefix (default - [Streaming] release title with current Mon'YY in IST)
-        required: false
-        default: ""
 
 permissions:
   contents: write

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -412,7 +412,7 @@ jobs:
             title="[${FEATURE_BRANCH}] ${PR_TITLE_INPUT}"
           else
             release_month_year="$(TZ=Asia/Kolkata date +"%b'%y")"
-            title="[${FEATURE_BRANCH}] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - ${release_month_year}"
+            title="[${FEATURE_BRANCH}] - [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - ${release_month_year}"
           fi
 
           {

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -56,7 +56,7 @@ Optional `-f pr_title='Custom release title'` overrides the default suffix. When
 
 `[CONNECTOR-1645] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Aug'26`
 
-(month/year are set automatically from the current date in IST). Reviewers `mphanias`, `abhilashmandaliya`, and `vivekashub` are requested on every release PR.
+(month/year are set automatically from the current date in IST). Reviewers `mphanias`, `abhilashmandaliya`, and `VivekASHub` are requested on every release PR.
 
 **Manual run**
 

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -52,7 +52,11 @@ gh workflow run package-connector-charts.yaml \
   -f version_bump=patch
 ```
 
-Optional `-f pr_title='My ticket title'` sets the PR title as `[CONNECTOR-1645] My ticket title`.
+Optional `-f pr_title='Custom release title'` overrides the default suffix. When omitted, the PR title is:
+
+`[CONNECTOR-1645] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Aug'26`
+
+(month/year are set automatically from the current date in IST). Reviewers `mphanias`, `abhilashmandaliya`, and `vivekashub` are requested on every release PR.
 
 **Manual run**
 
@@ -64,7 +68,7 @@ Manual runs require permission to trigger workflows on this repository (configur
 
 **Pull request runs**
 
-When a pull request changes connector chart files, the workflow runs integration tests only for the affected connector chart directories. Workflow or CI documentation-only changes do not schedule integration tests on the pull request.
+Pull requests only trigger this workflow when `.github/workflows/connector-integration-tests.yaml` itself changes (human-authored CI PRs). Chart release PRs run integration tests via **Package Connector Helm Charts** instead, which avoids GitHub's approval gate for `pull_request` workflows using secrets on bot-created commits.
 
 Fork pull requests are skipped automatically because repository secrets are unavailable.
 
@@ -98,9 +102,9 @@ Charts not listed in overrides use `version_bump`. With `version_bump=none`, onl
 | Input | Purpose |
 |---|---|
 | `branch_name` | JIRA feature branch and PR head (e.g. `CONNECTOR-1645`) |
-| `pr_title` | Optional title after the JIRA prefix; default is `Bump connector Helm chart versions` |
+| `pr_title` | Optional title suffix after the JIRA prefix; default is `[Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Mon'YY` (IST) |
 
-If the feature branch already exists it is reused; otherwise it is created from `main` on the first push.
+If the feature branch already exists it is reused; otherwise it is created from `main` on the first push. New `docs/index.yaml` entries use `Asia/Kolkata` timestamps to match prior releases.
 
 ```bash
 gh workflow run package-connector-charts.yaml \

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -68,7 +68,7 @@ Manual runs require permission to trigger workflows on this repository (configur
 
 **Pull request runs**
 
-Pull requests only trigger this workflow when `.github/workflows/connector-integration-tests.yaml` itself changes (human-authored CI PRs). Chart release PRs run integration tests via **Package Connector Helm Charts** instead, which avoids GitHub's approval gate for `pull_request` workflows using secrets on bot-created commits.
+Pull requests trigger this workflow when connector **test or CI** files change (`ci/connectors/**`, `aerospike-*/tests/**`, or `.github/workflows/connector-integration-tests.yaml`). Changes to chart packaging files alone (`Chart.yaml`, `README.md`, `docs/`) do not trigger it; those release PRs run tests via **Package Connector Helm Charts** instead.
 
 Fork pull requests are skipped automatically because repository secrets are unavailable.
 

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -106,6 +106,8 @@ Charts not listed in overrides use `version_bump`. With `version_bump=none`, onl
 
 If the feature branch already exists it is reused; otherwise it is created from `main` on the first push. New `docs/index.yaml` entries use `Asia/Kolkata` timestamps to match prior releases.
 
+After packaging, the workflow verifies each `.tgz` with `helm show chart`, prints `sha256sum`, and confirms the digest matches `docs/index.yaml` (also included in the release PR body).
+
 ```bash
 gh workflow run package-connector-charts.yaml \
   --ref main \

--- a/ci/connectors/build_scripts/build_connector_helm_indexing.sh
+++ b/ci/connectors/build_scripts/build_connector_helm_indexing.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export TZ=Asia/Kolkata
+
 # Merge index entries for packaged charts without resetting `created` on prior releases.
 # Pass chart directory names (same as helm package args); omit args for legacy full re-index.
 #


### PR DESCRIPTION
## Summary

Follow-up CI improvements for the connector packaging workflow after the initial merge to `main`.

- **Index timestamps** — set `TZ=Asia/Kolkata` during `helm package` / `helm repo index` so new `docs/index.yaml` entries use `+05:30` like prior releases (instead of UTC on GHA)
- **Release PR title** — default title is now `[CONNECTOR-ABCD] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Mon'YY` with month/year generated automatically in IST (`pr_title` still overrides the suffix)
- **Reviewers** — packaging workflow always requests `mphanias`, `abhilashmandaliya`, and `VivekASHub` on release PRs
- **Integration tests** — chart release PRs no longer trigger duplicate `pull_request` integration test runs that required maintainer approval for `FEATURES_CONF`; tests continue via `workflow_call` from **Package Connector Helm Charts**. CI/test-only PRs still auto-run tests when `ci/connectors/**` or `aerospike-*/tests/**` change
- **Artifact verification** — after packaging and index refresh, the workflow runs `helm show chart` on each `.tgz`, prints `sha256sum`, validates the digest against `docs/index.yaml`, and includes a **Packaged artifacts** table in the release PR body

## Test plan

- [ ] Merge and run **Package Connector Helm Charts** from `main` with `branch_name=CONNECTOR-1645`
- [ ] Confirm release PR title uses current month/year (e.g. `Aug'26`)
- [ ] Confirm reviewers are requested on the release PR
- [ ] Confirm new `docs/index.yaml` `created` timestamps use `+05:30`
- [ ] Confirm integration tests run via packaging workflow without PR approval gate
- [ ] Confirm packaging logs show artifact verification (`helm show chart`, SHA256 vs index digest) and release PR body includes the artifacts table