### PR TITLE
[CONNECTOR-1645] Fix release CI false greens and skip Dependabot integration tests

### DIFF
--- a/.github/workflows/connector-integration-tests.yaml
+++ b/.github/workflows/connector-integration-tests.yaml
@@ -158,6 +158,14 @@ jobs:
               exit 0
             fi
 
+            if [[ "${{ github.event.pull_request.head.ref }}" == dependabot/* ]] \
+              || [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
+              echo "Skipping Dependabot pull request (secrets unavailable for integration tests)."
+              echo 'connectors_json={"connector":[]}' >> "${GITHUB_OUTPUT}"
+              echo "has_connectors=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
             changed_files="$(git diff --name-only "origin/${BASE_REF}"...HEAD)"
 
             if echo "${changed_files}" | grep -q '^ci/connectors/'; then

--- a/.github/workflows/connector-integration-tests.yaml
+++ b/.github/workflows/connector-integration-tests.yaml
@@ -103,16 +103,48 @@ jobs:
     outputs:
       connectors_json: ${{ steps.build-matrix.outputs.connectors_json }}
       has_connectors: ${{ steps.build-matrix.outputs.has_connectors }}
+      checkout_ref: ${{ steps.checkout-ref.outputs.ref }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
+      - name: Resolve checkout ref
+        id: checkout-ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_CALL_GIT_REF: ${{ inputs.git_ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          case "${EVENT_NAME}" in
+            workflow_call)
+              if [ -n "${WORKFLOW_CALL_GIT_REF}" ]; then
+                ref="${WORKFLOW_CALL_GIT_REF}"
+              else
+                ref="${GITHUB_REF#refs/heads/}"
+                ref="${ref#refs/tags/}"
+              fi
+              ;;
+            pull_request)
+              ref="${PR_HEAD_REF}"
+              ;;
+            *)
+              ref="${GITHUB_REF#refs/heads/}"
+              ref="${ref#refs/tags/}"
+              ;;
+          esac
+
+          echo "Checkout ref: ${ref}"
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout repository
         if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ steps.checkout-ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Build connector test matrix
@@ -213,8 +245,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.git_ref != '' && inputs.git_ref || github.ref }}
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
           fetch-depth: 0
+
+      - name: Verify checked out chart versions
+        run: |
+          set -euo pipefail
+
+          echo "Checked out commit: $(git rev-parse HEAD)"
+          git log -1 --oneline
+          version="$(grep '^version:' "${{ matrix.connector }}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+          app_version="$(grep '^appVersion:' "${{ matrix.connector }}/Chart.yaml" | head -n1 | awk '{print $2}' | tr -d '"')"
+          echo "${{ matrix.connector }}: version=${version} appVersion=${app_version}"
 
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/package-connector-charts.yaml
+++ b/.github/workflows/package-connector-charts.yaml
@@ -80,6 +80,7 @@ jobs:
     outputs:
       charts: ${{ steps.selected-charts.outputs.charts }}
       feature_branch: ${{ steps.feature-branch.outputs.name }}
+      git_ref: ${{ steps.test-git-ref.outputs.ref }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -282,6 +283,37 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_ENV}"
 
+      - name: Verify connector Docker images exist
+        env:
+          CHARTS: ${{ steps.selected-charts.outputs.charts }}
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r chart; do
+            [ -n "${chart}" ] || continue
+
+            chart_yaml="${chart}/Chart.yaml"
+            values_yaml="${chart}/values.yaml"
+            app_version="$(grep '^appVersion:' "${chart_yaml}" | head -n1 | awk '{print $2}' | tr -d '"')"
+            repository="$(grep 'repository:' "${values_yaml}" | head -n1 | awk '{print $2}')"
+            image_tag="$(grep 'tag:' "${values_yaml}" | head -n1 | awk '{print $2}' | tr -d '"')"
+
+            if [ -z "${image_tag}" ]; then
+              image_tag="${app_version}"
+            fi
+
+            image="${repository}:${image_tag}"
+            echo "Checking Docker image ${image}"
+
+            http_code="$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${repository}/tags/${image_tag}/")"
+            if [ "${http_code}" != "200" ]; then
+              echo "::error::Docker image not found: ${image} (HTTP ${http_code}). Publish the connector image before releasing this chart version."
+              exit 1
+            fi
+
+            echo "${image} exists"
+          done <<< "${CHARTS}"
+
       - name: Package selected connector charts
         env:
           CHARTS: ${{ steps.selected-charts.outputs.charts }}
@@ -409,7 +441,7 @@ jobs:
           fi
 
           if [ -n "${PR_TITLE_INPUT}" ]; then
-            title="[${FEATURE_BRANCH}] ${PR_TITLE_INPUT}"
+            title="[${FEATURE_BRANCH}] - ${PR_TITLE_INPUT}"
           else
             release_month_year="$(TZ=Asia/Kolkata date +"%b'%y")"
             title="[${FEATURE_BRANCH}] - [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - ${release_month_year}"
@@ -461,6 +493,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Create or update pull request
+        id: create-pull-request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -471,6 +504,23 @@ jobs:
           title: ${{ steps.pr-metadata.outputs.title }}
           body: ${{ steps.pr-metadata.outputs.body }}
           reviewers: mphanias,abhilashmandaliya,VivekASHub
+
+      - name: Resolve integration test git ref
+        id: test-git-ref
+        env:
+          HEAD_SHA: ${{ steps.create-pull-request.outputs.pull-request-head-sha }}
+          FEATURE_BRANCH: ${{ steps.feature-branch.outputs.name }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${HEAD_SHA}" ]; then
+            ref="${HEAD_SHA}"
+          else
+            ref="${FEATURE_BRANCH}"
+          fi
+
+          echo "Integration tests will checkout: ${ref}"
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
 
   integration-tests:
     needs: package-connector-charts
@@ -485,4 +535,4 @@ jobs:
       aerospike_kafka_outbound: ${{ github.event.inputs.aerospike_kafka_outbound == 'true' }}
       aerospike_pulsar_outbound: ${{ github.event.inputs.aerospike_pulsar_outbound == 'true' }}
       aerospike_xdr_proxy: ${{ github.event.inputs.aerospike_xdr_proxy == 'true' }}
-      git_ref: ${{ needs.package-connector-charts.outputs.feature_branch }}
+      git_ref: ${{ needs.package-connector-charts.outputs.git_ref }}

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -70,7 +70,7 @@ Manual runs require permission to trigger workflows on this repository (configur
 
 Pull requests trigger this workflow when connector **test or CI** files change (`ci/connectors/**`, `aerospike-*/tests/**`, or `.github/workflows/connector-integration-tests.yaml`). Changes to chart packaging files alone (`Chart.yaml`, `README.md`, `docs/`) do not trigger it; those release PRs run tests via **Package Connector Helm Charts** instead.
 
-Fork pull requests are skipped automatically because repository secrets are unavailable.
+Fork and Dependabot pull requests are skipped automatically because repository secrets (including `FEATURES_CONF`) are unavailable on those `pull_request` runs. Re-running failed PR jobs or triggering **Connector Integration Tests** manually does not update PR checks; merge the skip fix to `main`, update the Dependabot branch, then re-run PR checks (or merge with admin override after a manual green run).
 
 Test logs are uploaded as workflow artifacts for 14 days.
 

--- a/ci/connectors/README.md
+++ b/ci/connectors/README.md
@@ -54,7 +54,7 @@ gh workflow run package-connector-charts.yaml \
 
 Optional `-f pr_title='Custom release title'` overrides the default suffix. When omitted, the PR title is:
 
-`[CONNECTOR-1645] [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Aug'26`
+`[CONNECTOR-1645] - [Streaming] Aerospike Streaming Connectors - Security vulnerabilities - Aug'26`
 
 (month/year are set automatically from the current date in IST). Reviewers `mphanias`, `abhilashmandaliya`, and `VivekASHub` are requested on every release PR.
 
@@ -106,7 +106,7 @@ Charts not listed in overrides use `version_bump`. With `version_bump=none`, onl
 
 If the feature branch already exists it is reused; otherwise it is created from `main` on the first push. New `docs/index.yaml` entries use `Asia/Kolkata` timestamps to match prior releases.
 
-After packaging, the workflow verifies each `.tgz` with `helm show chart`, prints `sha256sum`, and confirms the digest matches `docs/index.yaml` (also included in the release PR body).
+After packaging, the workflow verifies each connector Docker image exists on Docker Hub (using `values.yaml` `image.repository` and `appVersion`), verifies each `.tgz` with `helm show chart`, prints `sha256sum`, and confirms the digest matches `docs/index.yaml` (also included in the release PR body). Integration tests checkout the pushed release commit (SHA when available), not the caller branch.
 
 ```bash
 gh workflow run package-connector-charts.yaml \


### PR DESCRIPTION
## Summary

- **Fix false-green release pipeline:** integration tests invoked by **Package Connector Helm Charts** now checkout the pushed release commit (PR head SHA), not the caller branch (`main`). A prepare-job step resolves the ref reliably instead of using `inputs` in matrix jobs.
- **Block releases for missing Docker images:** packaging verifies each selected connector image exists on Docker Hub (`values.yaml` `image.repository` + `appVersion`) before `helm package`.
- **Skip Dependabot PR integration tests:** Dependabot `pull_request` runs skip connector tests because repository secrets (`FEATURES_CONF`) are unavailable on those workflows.

## Context

Run [#31572524514](https://github.com/aerospike/helm-charts/actions/runs/31572524514) packaged kafka outbound **6.0.4** while integration tests checked out **`main`** (kafka **6.0.2**), so tests passed despite `aerospike/aerospike-kafka-outbound:6.0.4` not existing on Docker Hub.

Dependabot PRs #103/#104 trigger integration tests on workflow changes and fail with empty `FEATURES_CONF`. Re-running failed PR jobs or manual `workflow_dispatch` does not update PR checks.

## Test plan

- [ ] Merge to `main`
- [ ] Re-run **Package Connector Helm Charts** on a feature branch — integration test logs should show the release commit SHA and matching chart `appVersion`
- [ ] Confirm packaging fails when bumping to a connector version with no Docker Hub image
- [ ] Update Dependabot PR branch from `main` and re-run checks — integration tests should skip with success
- [ ] Optionally run **Connector Integration Tests** manually from a Dependabot branch to validate the action bump (does not affect PR checks)